### PR TITLE
Transform module path to retrieve correct telemetry data

### DIFF
--- a/transforms/no-implicit-this/helpers/utils/get-telemetry-for.js
+++ b/transforms/no-implicit-this/helpers/utils/get-telemetry-for.js
@@ -105,7 +105,8 @@ function getModulePathFor(filePath, addonPaths = ADDON_PATHS, appPaths = APP_PAT
  */
 function getTelemetryFor(filePath) {
   let modulePath = getModulePathFor(filePath);
-  let data = telemetry[modulePath];
+  let moduleKey = modulePath.replace('templates/components/', 'components/');
+  let data = telemetry[moduleKey];
 
   return data;
 }


### PR DESCRIPTION
Fixes https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/7

From my original comment at https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/7#issuecomment-513369899

Classicly structured Ember apps are not being modified because retrieving the component telemetry data isn't working. Data is not retrieved because the key used doesn't match how it is stored.

**Key (module path to file being code-modded):** `test-app/templates/components/test-component`
**Telemetry hash key:** `test-app/components/test-component` 

The fix is simple in that I'm replacing `templates/components/` with `components/`. I tested this on the sample app from issue description and it worked.


