### PR TITLE
Add ES5 getters to telemetry data

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "codemod-cli": "^1.1.0",
-    "ember-codemods-telemetry-helpers": "^0.2.0",
+    "ember-codemods-telemetry-helpers": "^0.3.0",
     "ember-template-recast": "^3.1.1",
     "fs-extra": "^8.1.0",
     "git-repo-info": "^2.1.0",

--- a/transforms/no-implicit-this/__testfixtures__/-mock-telemetry.json
+++ b/transforms/no-implicit-this/__testfixtures__/-mock-telemetry.json
@@ -43,7 +43,8 @@
   },
   "handlebars-without-params.input": {
     "type": "Component",
-    "computedProperties": ["foo", "property"]
+    "computedProperties": ["foo", "property"],
+    "getters": ["someGetter"]
   },
   "my-helper": { "type": "Helper" },
   "a-helper": { "type": "Helper" },

--- a/transforms/no-implicit-this/__testfixtures__/handlebars-without-params.input.hbs
+++ b/transforms/no-implicit-this/__testfixtures__/handlebars-without-params.input.hbs
@@ -3,3 +3,4 @@
 {{foo}}
 {{property}}
 {{namespace/foo}}
+{{someGetter}}

--- a/transforms/no-implicit-this/__testfixtures__/handlebars-without-params.output.hbs
+++ b/transforms/no-implicit-this/__testfixtures__/handlebars-without-params.output.hbs
@@ -3,3 +3,4 @@
 {{this.foo}}
 {{this.property}}
 {{namespace/foo}}
+{{this.someGetter}}

--- a/transforms/no-implicit-this/helpers/plugin.js
+++ b/transforms/no-implicit-this/helpers/plugin.js
@@ -80,12 +80,13 @@ function doesTokenNeedThis(
     return false;
   }
 
-  let { computedProperties, ownActions, ownProperties } = runtimeData;
+  let { computedProperties, getters, ownActions, ownProperties } = runtimeData;
   let isComputed = (computedProperties || []).includes(token);
   let isAction = (ownActions || []).includes(token);
   let isProperty = (ownProperties || []).includes(token);
+  let isGetter = (getters || []).includes(token);
 
-  let needsThis = isComputed || isAction || isProperty;
+  let needsThis = isComputed || isAction || isProperty || isGetter;
 
   if (needsThis) {
     return true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,10 +2214,10 @@ electron-to-chromium@^1.3.191:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.191.tgz#c451b422cd8b2eab84dedabab5abcae1eaefb6f0"
   integrity sha512-jasjtY5RUy/TOyiUYM2fb4BDaPZfm6CXRFeJDMfFsXYADGxUN49RBqtgB7EL2RmJXeIRUk9lM1U6A5yk2YJMPQ==
 
-ember-codemods-telemetry-helpers@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-codemods-telemetry-helpers/-/ember-codemods-telemetry-helpers-0.2.0.tgz#d415d0f80f8e51927f030ce2787d2f38e411bf85"
-  integrity sha512-wAUjLRQ/E+xgCxwyQ1tAECHLO80CWALdNN+cgBhFSIO1Xv0oSWIowjEIwQRtjgTVMxhTFtQxBzGeBivazf9+VQ==
+ember-codemods-telemetry-helpers@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-codemods-telemetry-helpers/-/ember-codemods-telemetry-helpers-0.3.0.tgz#4ef3654d2fba138e50e559da33c2c9b94e40b332"
+  integrity sha512-sbBcb6MEYQMiVahtK3SZ3MJxvxMLx3STgxk6fLuS73kucYlnxI07I6jSIm2UX4E64jRvey9UbzejNqwpy1nJwg==
   dependencies:
     fs-extra "^8.1.0"
     git-repo-info "^2.1.0"


### PR DESCRIPTION
While working on https://github.com/ember-codemods/ember-no-implicit-this-codemod/pull/9 and testing against the test app raised with the original issue, [dustinsoftware/ember-quickstart-codemod](https://github.com/dustinsoftware/ember-quickstart-codemod), that not all telemetry data was gathered for the test component, [old-school](https://github.com/dustinsoftware/ember-quickstart-codemod/blob/master/app/components/old-school.js).

```js
import Component from '@ember/component';

export default class OldSchool extends Component.extend({
  // anything which *must* be merged to prototype here
}) {
  constructor() { super(...arguments); this.noSchool = 'No school'; }
  get theOldSchool() {
    return "the old school"
  }
  // normal class body definition here
}
```

The output telemetry looked like:

```json
'ember-quickstart/components/old-school':
   { computedProperties: [],
     ownActions: [],
     ownProperties: [],
     type: 'Component' },
```

With this change the telemetry now returns

```json
'ember-quickstart/components/old-school':
   { computedProperties: [],
     getters: [ 'theOldSchool' ],
     ownActions: [],
     ownProperties: [],
     type: 'Component' },
```

Notice we are also missing out on the `this.noSchool` assignment in the `constructor` but that's a separate issue 😄 

Also I snuck a small `.gitignore` update in too but if you want me to pull that out to a separate PR just let me know.