### PR TITLE
Add failing test for newline after `as`

### DIFF
--- a/transforms/no-implicit-this/__testfixtures__/-mock-telemetry.json
+++ b/transforms/no-implicit-this/__testfixtures__/-mock-telemetry.json
@@ -50,6 +50,10 @@
     "type": "Component",
     "computedProperties": ["previewImageUrl"]
   },
+  "failing-elements.input": {
+    "type": "Component",
+    "computedProperties": ["value"]
+  },
   "my-helper": { "type": "Helper" },
   "a-helper": { "type": "Helper" },
   "link-to": { "type": "Helper" },

--- a/transforms/no-implicit-this/__testfixtures__/failing-elements.input.hbs
+++ b/transforms/no-implicit-this/__testfixtures__/failing-elements.input.hbs
@@ -1,0 +1,3 @@
+<MyComponent @someArg={{value}} as
+|myComponent|>
+</MyComponent>

--- a/transforms/no-implicit-this/__testfixtures__/failing-elements.output.hbs
+++ b/transforms/no-implicit-this/__testfixtures__/failing-elements.output.hbs
@@ -1,0 +1,3 @@
+<MyComponent @someArg={{this.value}} as
+|myComponent|>
+</MyComponent>


### PR DESCRIPTION
Failing test for https://github.com/ember-codemods/ember-no-implicit-this-codemod/issues/24