### PR TITLE
Move `getTelemetry()` call out of `plugin.js` file

### DIFF
--- a/transforms/no-implicit-this/helpers/plugin.js
+++ b/transforms/no-implicit-this/helpers/plugin.js
@@ -11,7 +11,8 @@ function transformPlugin(env, options = {}) {
   let { builders: b } = env.syntax;
 
   let scopedParams = [];
-  let [components, helpers] = populateInvokeables();
+  let telemetry = getTelemetry();
+  let [components, helpers] = populateInvokeables(telemetry);
 
   let customHelpers = options.customHelpers || [];
 
@@ -146,10 +147,9 @@ function transformPlugin(env, options = {}) {
   };
 }
 
-function populateInvokeables() {
+function populateInvokeables(telemetry) {
   let components = [];
   let helpers = [];
-  let telemetry = getTelemetry();
 
   for (let name of Object.keys(telemetry)) {
     let entry = telemetry[name];

--- a/transforms/no-implicit-this/helpers/plugin.js
+++ b/transforms/no-implicit-this/helpers/plugin.js
@@ -1,4 +1,3 @@
-const { getTelemetry } = require('ember-codemods-telemetry-helpers');
 // everything is copy-pasteable to astexplorer.net.
 // sorta. telemetry needs to be defined.
 // telemtry can be populated with -mock-telemetry.json
@@ -11,7 +10,7 @@ function transformPlugin(env, options = {}) {
   let { builders: b } = env.syntax;
 
   let scopedParams = [];
-  let telemetry = getTelemetry();
+  let telemetry = options.telemetry || {};
   let [components, helpers] = populateInvokeables(telemetry);
 
   let customHelpers = options.customHelpers || [];

--- a/transforms/no-implicit-this/index.js
+++ b/transforms/no-implicit-this/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 
 const recast = require('ember-template-recast');
+const { getTelemetry } = require('ember-codemods-telemetry-helpers');
 const transformPlugin = require('./helpers/plugin');
 const { getOptions: getCLIOptions } = require('codemod-cli');
 const DEFAULT_OPTIONS = {};
@@ -34,6 +35,7 @@ function getOptions() {
   let cliOptions = getCLIOptions();
   let options = {
     customHelpers: _getCustomHelpersFromConfig(cliOptions.config),
+    telemetry: getTelemetry(),
   };
   return options;
 }


### PR DESCRIPTION
This will make the recast transform easier to test since it no longer relies on the telemetry cache and can just work with the raw telemetry data directly.