### PR TITLE
Replace `recast.transform()` call with `recast.traverse()`

### DIFF
--- a/transforms/no-implicit-this/helpers/plugin.js
+++ b/transforms/no-implicit-this/helpers/plugin.js
@@ -1,3 +1,5 @@
+const recast = require('ember-template-recast');
+
 // everything is copy-pasteable to astexplorer.net.
 // sorta. telemetry needs to be defined.
 // telemtry can be populated with -mock-telemetry.json
@@ -6,8 +8,8 @@ const KNOWN_HELPERS = require('./known-helpers');
 /**
  * plugin entrypoint
  */
-function transformPlugin(env, options = {}) {
-  let { builders: b } = env.syntax;
+function transform(root, options = {}) {
+  let b = recast.builders;
 
   let scopedParams = [];
   let telemetry = options.telemetry || {};
@@ -73,7 +75,7 @@ function transformPlugin(env, options = {}) {
 
   let inAttrNode = false;
 
-  return {
+  recast.traverse(root, {
     Block: paramTracker,
     ElementNode: paramTracker,
 
@@ -143,7 +145,7 @@ function transformPlugin(env, options = {}) {
       // <div {{foo bar=BAZ}} />
       handleHash(node.hash);
     },
-  };
+  });
 }
 
 function populateInvokeables(telemetry) {
@@ -166,4 +168,4 @@ function populateInvokeables(telemetry) {
   return [components, helpers];
 }
 
-module.exports = transformPlugin;
+module.exports = transform;

--- a/transforms/no-implicit-this/index.js
+++ b/transforms/no-implicit-this/index.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const recast = require('ember-template-recast');
 const { getTelemetry } = require('ember-codemods-telemetry-helpers');
-const transformPlugin = require('./helpers/plugin');
+const transform = require('./helpers/plugin');
 const { getOptions: getCLIOptions } = require('codemod-cli');
 const DEFAULT_OPTIONS = {};
 
@@ -49,5 +49,7 @@ module.exports = function transformer(file /*, api */) {
     return;
   }
 
-  return recast.transform(file.source, env => transformPlugin(env, options)).code;
+  let root = recast.parse(file.source);
+  transform(root, options);
+  return recast.print(root);
 };


### PR DESCRIPTION
This makes the transform code more flexible and no longer reliant on the `env` parameter, which makes the code easier to test