### PR TITLE
Support transforming templates embedded in JS/TS files

### DIFF
--- a/transforms/no-implicit-this/__testfixtures__/tagged-templates-js.input.js
+++ b/transforms/no-implicit-this/__testfixtures__/tagged-templates-js.input.js
@@ -1,0 +1,16 @@
+import { hbs as echHBS } from 'ember-cli-htmlbars';
+import hipHBS from 'htmlbars-inline-precompile';
+import echipHBS from 'ember-cli-htmlbars-inline-precompile';
+import { hbs } from 'unknown-tag-source';
+
+echHBS`
+  Hello,
+    {{target}}!
+  \n
+`;
+
+hipHBS`Hello, {{target}}!`;
+
+echipHBS`Hello, {{target}}!`;
+
+hbs`Hello, {{target}}!`;

--- a/transforms/no-implicit-this/__testfixtures__/tagged-templates-js.output.js
+++ b/transforms/no-implicit-this/__testfixtures__/tagged-templates-js.output.js
@@ -1,0 +1,16 @@
+import { hbs as echHBS } from 'ember-cli-htmlbars';
+import hipHBS from 'htmlbars-inline-precompile';
+import echipHBS from 'ember-cli-htmlbars-inline-precompile';
+import { hbs } from 'unknown-tag-source';
+
+echHBS`
+  Hello,
+    {{this.target}}!
+  \n
+`;
+
+hipHBS`Hello, {{this.target}}!`;
+
+echipHBS`Hello, {{this.target}}!`;
+
+hbs`Hello, {{target}}!`;

--- a/transforms/no-implicit-this/__testfixtures__/tagged-templates-ts.input.ts
+++ b/transforms/no-implicit-this/__testfixtures__/tagged-templates-ts.input.ts
@@ -1,0 +1,17 @@
+import { hbs as echHBS } from 'ember-cli-htmlbars';
+import hipHBS from 'htmlbars-inline-precompile';
+import echipHBS from 'ember-cli-htmlbars-inline-precompile';
+
+declare const hbs: unknown;
+
+echHBS`
+  Hello,
+    {{target}}!
+  \n
+`;
+
+hipHBS`Hello, {{target}}!`;
+
+echipHBS`Hello, {{target}}!`;
+
+hbs`Hello, {{target}}!`;

--- a/transforms/no-implicit-this/__testfixtures__/tagged-templates-ts.output.ts
+++ b/transforms/no-implicit-this/__testfixtures__/tagged-templates-ts.output.ts
@@ -1,0 +1,17 @@
+import { hbs as echHBS } from 'ember-cli-htmlbars';
+import hipHBS from 'htmlbars-inline-precompile';
+import echipHBS from 'ember-cli-htmlbars-inline-precompile';
+
+declare const hbs: unknown;
+
+echHBS`
+  Hello,
+    {{this.target}}!
+  \n
+`;
+
+hipHBS`Hello, {{this.target}}!`;
+
+echipHBS`Hello, {{this.target}}!`;
+
+hbs`Hello, {{target}}!`;

--- a/transforms/no-implicit-this/helpers/tagged-templates.js
+++ b/transforms/no-implicit-this/helpers/tagged-templates.js
@@ -1,0 +1,42 @@
+const TEMPLATE_TAG_IMPORTS = [
+  { source: 'ember-cli-htmlbars', name: 'hbs' },
+  { source: 'htmlbars-inline-precompile', name: 'default' },
+  { source: 'ember-cli-htmlbars-inline-precompile', name: 'default' },
+];
+
+// Identifies whether a TaggedTemplateExpression corresponds to an Ember template
+// using one of a known set of `hbs` tags.
+exports.isEmberTemplate = function isEmberTemplate(path) {
+  let tag = path.get('tag');
+  let hasInterpolation = path.node.quasi.quasis.length !== 1;
+  let isKnownTag = TEMPLATE_TAG_IMPORTS.some(({ source, name }) =>
+    isImportReference(tag, source, name)
+  );
+
+  return isKnownTag && !hasInterpolation;
+};
+
+// Determines whether the given identifier is a reference to an export
+// from a particular module.
+function isImportReference(path, importSource, importName) {
+  let scope = path.scope.lookup(path.node.name);
+  let bindings = scope ? scope.getBindings() : {};
+  let bindingIdentifiers = bindings[path.node.name] || [];
+
+  for (let binding of bindingIdentifiers) {
+    let specifier = binding.parent.node;
+    let importDeclaration = binding.parent.parent.node;
+    let bindingImportedName =
+      specifier.type === 'ImportDefaultSpecifier'
+        ? 'default'
+        : specifier.type === 'ImportSpecifier'
+        ? specifier.imported.name
+        : null;
+
+    if (bindingImportedName === importName && importDeclaration.source.value === importSource) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR updates the codemod to search for tagged template strings in JS and TS files and apply the existing transform to them as well. This should fix #262.